### PR TITLE
Correction in order to return 131 as return code value when a blockin…

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jbocktor <jbocktor@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/12 16:49:01 by hauerbac          #+#    #+#             */
-/*   Updated: 2024/05/30 11:20:58 by hauerbac         ###   ########.fr       */
+/*   Updated: 2024/05/31 16:12:08 by hauerbac         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,6 @@ int		files_open(t_token *t);
 int		check_and_run_bi(t_data *d, t_cmd *bi, int fd2);
 int		run_bi_without_fork(t_data *d, t_token *t);
 void	set_signals_actions_in_fork(t_dll *lst, t_list *current);
-
 int		built_cd(char ***envp, int *envp_size, char **cd);
 int		modify_pwd_value(int *envp_size, char ***envp, char *new_value,
 			char *exp);
@@ -96,7 +95,6 @@ int		built_export(char ***envp, int *envp_size, char **export,
 			int fd);
 int		built_pwd(char **pwd);
 int		built_unset(char ***envp, int *envp_size, char **unset);
-
 void	run_bi_in_fork(t_data *d, t_token *t, int ds[3], t_list *current);
 int		check_error_on_command(char *cmd);
 void	run_command(t_data *d, t_token *t, int ds[3], t_list *current);

--- a/srcs/run_cmds_minishell.c
+++ b/srcs/run_cmds_minishell.c
@@ -6,7 +6,7 @@
 /*   By: hauerbac <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/06 15:27:39 by hauerbac          #+#    #+#             */
-/*   Updated: 2024/05/22 19:54:28 by hauerbac         ###   ########.fr       */
+/*   Updated: 2024/05/31 16:34:17 by hauerbac         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,7 +123,7 @@ static int	run_subset_of_commands(t_data *d, t_list **start, int wstatus,
 		return (perror("waitpid failed"), EXIT_FAILURE);
 	if (WIFEXITED(wstatus))
 		return (WEXITSTATUS(wstatus));
-	return (display_error("Last command not exited error\n"), EXIT_FAILURE);
+	return (display_error("Last cmd signaled\n"), 128 + WTERMSIG(wstatus));
 }
 
 int	run_commands(t_data *d)
@@ -144,6 +144,10 @@ int	run_commands(t_data *d)
 	wstatus = 0;
 	w = 0;
 	while (start && start->content)
+	{
 		result = run_subset_of_commands(d, &start, wstatus, w);
+		if (g_exit_status != 130 && g_exit_status != 131)
+			g_exit_status = result;
+	}
 	return (result);
 }


### PR DESCRIPTION
…g command is terminated by the Ctrl+\ signal