### PR TITLE
Correction to send an equivalent to Ctrl+D to the next piped command …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jbocktor <jbocktor@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/02/12 17:04:21 by hauerbac          #+#    #+#              #
-#    Updated: 2024/06/04 12:54:02 by jbocktor         ###   ########.fr        #
+#    Updated: 2024/06/06 13:44:57 by hauerbac         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -62,6 +62,7 @@ SRCS =	free_2_minishell.c \
 	run_cmds_3_minishell.c \
 	run_cmds_2_minishell.c \
 	run_cmds_minishell.c \
+	parser_tokens_4_minishell.c \
 	parser_tokens_minishell.c \
 	debug_minishell.c \
 	process_interactive_mode_minishell.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jbocktor <jbocktor@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/12 16:49:01 by hauerbac          #+#    #+#             */
-/*   Updated: 2024/06/05 12:52:11 by hauerbac         ###   ########.fr       */
+/*   Updated: 2024/06/06 14:33:25 by hauerbac         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,8 @@ int		check_redir_files(t_dll_el **current, t_data *d,
 int		set_last_redir_files_names(t_token *t_cmdbi,
 			t_dll_el *start_el);
 int		add_to_cmds_list(t_data *d, t_token *t_cmdbi);
+void	force_in_redir_of_next_cmdbi(t_token *t_cmdbi,
+			int *next_has_to_be_forced, int *result);
 int		parse_tokens(t_data *d);
 int		files_open(t_token *t);
 int		check_and_run_bi(t_data *d, t_cmd *bi, int fd2);

--- a/srcs/parser_tokens_4_minishell.c
+++ b/srcs/parser_tokens_4_minishell.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_tokens_4_minishell.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hauerbac <marvin@42.fr>                    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 13:37:18 by hauerbac          #+#    #+#             */
+/*   Updated: 2024/06/06 15:04:41 by hauerbac         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	force_in_redir_of_next_cmdbi(t_token *t_cmdbi,
+		int *next_has_to_be_forced, int *result)
+{
+	if (t_cmdbi && (t_cmdbi->type == COMMAND || t_cmdbi->type == BI) \
+		&& t_cmdbi->cmd_d)
+	{
+		if (t_cmdbi->cmd_d->is_in_piped == 1 \
+			&& *next_has_to_be_forced == 1 \
+			&& !t_cmdbi->cmd_d->file1 \
+			&& !(*result == 3 || *result == -3))
+		{
+			t_cmdbi->cmd_d->file1 = (char *) malloc(sizeof(char) \
+									* 10);
+			if (!t_cmdbi->cmd_d->file1)
+				*result = -3;
+			ft_strlcpy(t_cmdbi->cmd_d->file1, "/dev/null", 10);
+		}
+		*next_has_to_be_forced = 0;
+	}
+}

--- a/srcs/parser_tokens_minishell.c
+++ b/srcs/parser_tokens_minishell.c
@@ -6,7 +6,7 @@
 /*   By: hauerbac <hauerbac@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/14 11:23:08 by hauerbac          #+#    #+#             */
-/*   Updated: 2024/05/15 17:06:27 by hauerbac         ###   ########.fr       */
+/*   Updated: 2024/06/06 14:35:53 by hauerbac         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,17 +123,25 @@ int	parse_tokens(t_data *d)
 	t_token		*t_cmdbi;
 	int			result;
 	int			is_piped;
+	int			forced;
 
 	if (!(d && d->lst && d->lst->size > 0))
 		return (-2);
 	is_piped = 0;
 	el_ptr = d->lst->head;
 	t_cmdbi = NULL;
-	while (el_ptr)
+	result = 0;
+	forced = 0;
+	while (el_ptr && !(result == 3 || result == -3))
 	{
 		result = find_cmd_or_bi(&t_cmdbi, &is_piped, &el_ptr, d);
 		if (result == 0 && t_cmdbi)
+		{
 			result = add_to_cmds_list(d, t_cmdbi);
+			force_in_redir_of_next_cmdbi(t_cmdbi, &forced, &result);
+		}
+		else if (!(result == 3 || result == -3))
+			forced = 1;
 	}
 	return (result);
 }

--- a/srcs/process_interactive_mode_minishell.c
+++ b/srcs/process_interactive_mode_minishell.c
@@ -6,7 +6,7 @@
 /*   By: hauerbac <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:38:11 by hauerbac          #+#    #+#             */
-/*   Updated: 2024/06/04 15:12:52 by hauerbac         ###   ########.fr       */
+/*   Updated: 2024/06/06 15:06:36 by hauerbac         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ int	process_a_line(char *a_line, t_data *d)
 				result = run_commands(d);
 		}
 	}
-	if (result == 3)
+	if (result == 3 || result == -3)
 		display_error("Malloc error\n");
 	if (a_line && ft_strlen(a_line) > 0)
 		d->return_code = result;


### PR DESCRIPTION
…or built-in which follows a not executed command or built-in because of an error of parsing (by example when the file "toto" doesn't exist : cat <toto | < toto ; echo Toto | < toto wc -l | cat)